### PR TITLE
Fix max_caps config default value

### DIFF
--- a/src/odin_pico/adapter.py
+++ b/src/odin_pico/adapter.py
@@ -21,7 +21,7 @@ class PicoAdapter(ApiAdapter):
         self.lock = threading.Lock()
         update_loop = True
         data_output_path = self.options.get("data_output_path", "/tmp/")
-        max_caps = int(self.options.get("max_caps", "/tmp/"))
+        max_caps = int(self.options.get("max_caps", 100000000))
 
         self.pico_controller = PicoController(self.lock, update_loop, data_output_path, max_caps)
 


### PR DESCRIPTION
This PR closes #29 and allows the adapter to start if no max_caps parameter present in configuration file.